### PR TITLE
Remove target=sample_collection from line 542

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -539,7 +539,6 @@ def _handle_calling(
     )
 
     params = dict(
-        target=sample_collection,
         label_input_choices="direct",
         delegate=delegate,
         labels=labels,


### PR DESCRIPTION
Removed `target=sample_collection` from param `dict` in line 542, which caused the `ZeroShotClassify` operator not to execute

